### PR TITLE
remove redundant body-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "author": "RPI Ambulance",
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "nodemailer": "^6.3.0"

--- a/server.js
+++ b/server.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const bodyParser = require('body-parser');
 require('dotenv').config();
 const nodemailer = require('nodemailer');
 const service_account = require('./keys/gmail_service_creds.json');
@@ -14,8 +13,8 @@ const HOMEPAGE = process.env.HOMEPAGE;
 // Initializes express app
 const app = express();
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended: false}));
+app.use(express.json());
+app.use(express.urlencoded({extended: false}));
 
 app.post('/sendmail', async(req, res) => {
     if (req.body.token !== WEBSITE_VERIFICATION_TOKEN) {


### PR DESCRIPTION
For express@^4.16, the body-parser was re-added as a core dependency,
and there is no reason to install it separately anymore. This
redundancy is further expressed in that the removal of the package
from the package.json did not change the package-lock.json.